### PR TITLE
List returns empty array not nil when no pull requests are present on a repo

### DIFF
--- a/lib/zenflow/helpers/pull_request.rb
+++ b/lib/zenflow/helpers/pull_request.rb
@@ -13,7 +13,7 @@ module Zenflow
 
       def find_by_ref(ref, options={})
         Zenflow::Log("Looking up pull request for #{ref}") unless options[:silent]
-        if list != []
+        if list.any?
           pull = list.detect do |p|
             p["head"]["ref"] == ref
           end


### PR DESCRIPTION
Some folks on my team were getting this error:

https://gist.github.com/khristian/6718700

When trying to do 'zenflow feature review'. Our repo doesn't have any open pull requests at the moment, and in that case 'list' returns `[]`, not `nil`, which is what `find_by_ref` seems to expect.

As a result, when `list` returned `[]`, `find_by_ref` would ignore the line `if !list.nil?` and try to proceed to call detect on list which inside the block resulted in the error I posted from the gist above.
