### PR TITLE
Preferentially create a PR to 'destination' when it exists

### DIFF
--- a/lib/zenflow/helpers/branch_commands/review.rb
+++ b/lib/zenflow/helpers/branch_commands/review.rb
@@ -16,7 +16,7 @@ module Zenflow
               already_created?(Zenflow::PullRequest.find_by_ref("#{flow}/#{branch_name}"))
 
               pull = Zenflow::PullRequest.create(
-                base:  branch(:source),
+                base:  branch(:destination) || branch(:source),
                 head:  "#{flow}/#{branch_name}",
                 title: "#{flow}: #{branch_name}",
                 body:  Zenflow::Ask("Describe this #{flow}:", required: true)

--- a/spec/zenflow/helpers/branch_command_spec.rb
+++ b/spec/zenflow/helpers/branch_command_spec.rb
@@ -177,7 +177,7 @@ module BranchCommandSpec
             pull = double(valid?: true)
             pull.stub(:[]).with("html_url").and_return("URL")
             Zenflow::PullRequest.should_receive(:create).with(
-              base:  "master",
+              base:  "production",
               head:  "test/new-test-branch",
               title: "test: new-test-branch",
               body:  "A great test"
@@ -195,7 +195,7 @@ module BranchCommandSpec
           before do
             Zenflow.should_receive(:Ask).with("Describe this test:", required: true).and_return("A great test")
             Zenflow::PullRequest.should_receive(:create).with(
-              base:  "master",
+              base:  "production",
               head:  "test/new-test-branch",
               title: "test: new-test-branch",
               body:  "A great test"


### PR DESCRIPTION
I was having problems with 'zenflow release review'. Specifically, it always failed because it was attempting to create a release branch from master, and then submit a PR to master, which would fail because there were no changes (we did just create it, after all).

Looking at the workflow of some other projects that use zenflow, it seems like 'zenflow release review' ought to create a PR from the release branch to the destination (usu. 'production'). Since none of the other flows seem to provide 'destination' this seems like the right approach.
