### PR TITLE
also merge hotfixes into master when they're finished

### DIFF
--- a/lib/zenflow/commands/hotfix.rb
+++ b/lib/zenflow/commands/hotfix.rb
@@ -3,9 +3,10 @@ module Zenflow
 
     flow "hotfix"
 
-    branch source: Zenflow::Config[:release_branch]
-    branch deploy: Zenflow::Config[:staging_branch]
-    branch deploy: Zenflow::Config[:qa_branch]
+    branch source:                Zenflow::Config[:release_branch]
+    branch deploy:                Zenflow::Config[:staging_branch]
+    branch deploy:                Zenflow::Config[:qa_branch]
+    branch secondary_destination: Zenflow::Config[:development_branch]
 
     changelog :rotate
     version :patch

--- a/lib/zenflow/helpers/branch_commands/finish.rb
+++ b/lib/zenflow/helpers/branch_commands/finish.rb
@@ -51,7 +51,7 @@ module Zenflow
             end
 
             def merge_branch_into_destination
-              [branch(:source), branch(:destination)].compact.each do |finish|
+              [branch(:source), branch(:destination), branch(:secondary_destination)].compact.each do |finish|
                 Zenflow::Branch.checkout(finish)
                 Zenflow::Branch.merge("#{flow}/#{branch_name}")
                 Zenflow::Branch.push(finish) if !options[:offline]

--- a/spec/zenflow/commands/hotfix_spec.rb
+++ b/spec/zenflow/commands/hotfix_spec.rb
@@ -7,6 +7,7 @@ describe Zenflow::Hotfix do
   it { expect(subject.flow).to eq("hotfix") }
   it { expect(subject.branch(:source)).to be_false }
   it { expect(subject.branch(:deploy)).to match_array(["staging", "qa"]) }
+  it { expect(subject.branch(:secondary_destination)).to eq("master") }
   it { expect(subject.changelog).to eq(:rotate) }
   it { expect(subject.version).to eq(:patch) }
   it { expect(subject.tag).to be_true }


### PR DESCRIPTION
Looks like release finishing was working correctly, but hotfix finishing was only merging into production.
I added a :secondary_destination rather than mimicking release's :destination because it updates from :destination before finishing, and updating a hotfix from master before finishing would be bad.
