### PR TITLE
Prevent feature branch push & track when merge strategy is rebase

### DIFF
--- a/lib/zenflow/helpers/branch_commands/start.rb
+++ b/lib/zenflow/helpers/branch_commands/start.rb
@@ -22,8 +22,10 @@ module Zenflow
               if !offline
                 Zenflow::Branch.update(branch(:source))
                 Zenflow::Branch.create("#{flow}/#{branch_name}", branch(:source))
-                Zenflow::Branch.push("#{flow}/#{branch_name}")
-                Zenflow::Branch.track("#{flow}/#{branch_name}")
+                unless Zenflow::Config[:merge_strategy] == 'rebase'
+                  Zenflow::Branch.push("#{flow}/#{branch_name}")
+                  Zenflow::Branch.track("#{flow}/#{branch_name}")
+                end
               else
                 Zenflow::Branch.checkout(branch(:source))
                 Zenflow::Branch.create("#{flow}/#{branch_name}", branch(:source))

--- a/spec/zenflow/helpers/branch_command_spec.rb
+++ b/spec/zenflow/helpers/branch_command_spec.rb
@@ -25,14 +25,28 @@ module BranchCommandSpec
 
     describe "#start" do
       context "when online" do
-        before do
-          Zenflow.should_receive(:Ask).and_return("new-test-branch")
-          Zenflow::Branch.should_receive(:update).with("master")
-          Zenflow::Branch.should_receive(:create).with("test/new-test-branch", "master")
-          Zenflow::Branch.should_receive(:push).with("test/new-test-branch")
-          Zenflow::Branch.should_receive(:track).with("test/new-test-branch")
+        context 'merge_strategy: merge' do
+          before do
+            Zenflow.should_receive(:Ask).and_return("new-test-branch")
+            Zenflow::Branch.should_receive(:update).with("master")
+            Zenflow::Branch.should_receive(:create).with("test/new-test-branch", "master")
+            Zenflow::Branch.should_receive(:push).with("test/new-test-branch")
+            Zenflow::Branch.should_receive(:track).with("test/new-test-branch")
+          end
+          it { TestCommand.new.invoke(:start) }
         end
-        it { TestCommand.new.invoke(:start) }
+
+        context 'merge_strategy: rebase' do
+          before do
+            Zenflow::Config.should_receive(:[]).with(:merge_strategy).and_return('rebase')
+            Zenflow.should_receive(:Ask).and_return("new-test-branch")
+            Zenflow::Branch.should_receive(:update).with("master")
+            Zenflow::Branch.should_receive(:create).with("test/new-test-branch", "master")
+            Zenflow::Branch.should_not_receive(:push).with("test/new-test-branch")
+            Zenflow::Branch.should_not_receive(:track).with("test/new-test-branch")
+          end
+          it { TestCommand.new.invoke(:start) }
+        end
       end
 
       context "when offline" do


### PR DESCRIPTION
This is the implementation from #15 as we discussed.

The fact that you chose a rebase strategy for `zenflow feature update` almost certainly means you do not want to publish your newly created feature branches immediately, so I just made it so, I didn't provide yet another point of friction during `zenflow init` that the user needs to worry about.

However, the thing zenflow does where it pushes and sets the newly created feature branch to track is nice, so I added a new command for 'publish' which is coming in another PR.

I added specs for both, they all pass, and I tested it locally on my current project by bundling to a branch that integrates both of these PRs. I am excite :) Hopefully you guys dig these changes. LMK if you need any tweaks.
