### PR TITLE
Remove "a" from stream.reopen when writing to log

### DIFF
--- a/lib/zenflow/helpers/shell.rb
+++ b/lib/zenflow/helpers/shell.rb
@@ -77,7 +77,7 @@ module Zenflow
       # Stolen from ActiveSupport
       def log_stream(stream)
         old_stream = stream.dup
-        stream.reopen(Zenflow::LOG_PATH, "a")
+        stream.reopen(Zenflow::LOG_PATH)
         stream.sync = true
         yield
       ensure


### PR DESCRIPTION
This didn't seem to stop the log from being written to (aka, the log still works), but it did fix the error I was seeing in #32.

[Fixes #32]
