### PR TITLE
Fix deploy to qa when false

### DIFF
--- a/lib/zenflow/commands/release.rb
+++ b/lib/zenflow/commands/release.rb
@@ -5,7 +5,7 @@ module Zenflow
 
     branch source: Zenflow::Config[:development_branch]
     branch deploy: Zenflow::Config[:staging_branch]
-    branch deploy: Zenflow::Config[:qa_branch]
+    branch deploy: Zenflow::Config[:qa_branch] unless Zenflow::Config[:qa_branch] == false
     branch destination: Zenflow::Config[:release_branch]
 
     changelog :rotate

--- a/lib/zenflow/helpers/branch_commands/deploy.rb
+++ b/lib/zenflow/helpers/branch_commands/deploy.rb
@@ -9,10 +9,12 @@ module Zenflow
           option :migrations, type: :boolean, desc: "Run migrations during deployment", aliases: :m
           def deploy
             branch_name
+            # FIXME: (2014-12-03) jonk => this needs to be added to the init script
             if !Zenflow::Config[:deployable]
               Zenflow::Log("This project is not deployable right now", color: :red)
               exit(1)
             end
+            # FIXME: (2014-12-03) jonk => why is it deploying to all branches at the same time?
             all_branches(:deploy).each do |branch|
               Zenflow::Branch.update(branch)
               Zenflow::Branch.merge("#{flow}/#{branch_name}")

--- a/lib/zenflow/helpers/branch_commands/review.rb
+++ b/lib/zenflow/helpers/branch_commands/review.rb
@@ -38,13 +38,15 @@ module Zenflow
 
             def handle_invalid_pull_request(pull)
               Zenflow::Log("There was a problem creating the pull request:", color: :red)
+              # FIXME: (2014-12-03) jonk => need to check for the existence of a production branch and give that as an error
               if pull["errors"]
                 pull["errors"].each do |error|
-                  Zenflow::Log("* #{error['message'].gsub(/^base\s*/,'')}", indent: true, color: :red)
+                  Zenflow::Log("* #{error['message'].to_s.gsub(/^base\s*/,'')}", indent: true, color: :red)
                 end
               elsif pull["message"]
                 Zenflow::Log("* #{pull['message']}", indent: true, color: :red)
               else
+                # FIXME: (2014-12-03) jonk => this doesn't get hit when it should
                 Zenflow::Log(" * unexpected failure, both 'errors' and 'message' were empty in the response")
               end
             end


### PR DESCRIPTION
This isn't ready yet, but putting in some notes for myself.

![image](https://cloud.githubusercontent.com/assets/4521/5285971/b4995480-7ae5-11e4-92dc-42503514d638.png)

Also:

Check for the presence of a VERSION.yml file

It needs to have:

```

---
major: 0
minor: 0
patch: 0
pre: 
```

Check for the presence of the names of the branches they specified so that `zenflow release review` will give a better error (ie when the production branch doesn't exist yet)
