### PR TITLE
Stop commiting all files

### DIFF
--- a/lib/zenflow/helpers/changelog.rb
+++ b/lib/zenflow/helpers/changelog.rb
@@ -30,7 +30,7 @@ module Zenflow
           f.write prepended_changelog
         end
         rotate(:name => options[:name]) if options[:rotate]
-        Zenflow::Shell["git add CHANGELOG.md && git commit -a -m 'Adding line to CHANGELOG: #{new_changes}'"]
+        Zenflow::Shell["git add CHANGELOG.md && git commit -m 'Adding line to CHANGELOG: #{new_changes}'"]
       end
 
       def prepended_changelog(new_changes)
@@ -50,7 +50,7 @@ module Zenflow
         File.open("CHANGELOG.md", "w") do |f|
           f.write changelog
         end
-        Zenflow::Shell["git add CHANGELOG.md && git commit -a -m 'Rotating CHANGELOG.'"] if options[:commit]
+        Zenflow::Shell["git add CHANGELOG.md && git commit -m 'Rotating CHANGELOG.'"] if options[:commit]
       end
 
       def rotated_changelog(options={})

--- a/lib/zenflow/helpers/version.rb
+++ b/lib/zenflow/helpers/version.rb
@@ -34,7 +34,7 @@ module Zenflow
     def self.update(level=:patch)
       new_version = Zenflow::Version.current.bump(level)
       new_version.save
-      Zenflow::Shell["git add VERSION.yml && git commit -a -m 'Bumping version to #{new_version}.'"]
+      Zenflow::Shell["git add VERSION.yml && git commit -m 'Bumping version to #{new_version}.'"]
       new_version
     end
 

--- a/spec/zenflow/helpers/changelog_spec.rb
+++ b/spec/zenflow/helpers/changelog_spec.rb
@@ -67,7 +67,7 @@ describe Zenflow::Changelog do
         file_handler.should_receive(:write).with('some other text I suppose')
         File.should_receive(:open).with("CHANGELOG.md", "w").and_yield(file_handler)
         Zenflow::Changelog.should_not_receive(:rotate)
-        Zenflow::Shell.should_receive(:run).with("git add CHANGELOG.md && git commit -a -m 'Adding line to CHANGELOG: changed the world'")
+        Zenflow::Shell.should_receive(:run).with("git add CHANGELOG.md && git commit -m 'Adding line to CHANGELOG: changed the world'")
         Zenflow::Changelog.prepend_change_to_changelog('changed the world')
       end
     end
@@ -76,7 +76,7 @@ describe Zenflow::Changelog do
       it "prepends changes to the changelog" do
         File.should_receive(:open).with("CHANGELOG.md", "w")
         Zenflow::Changelog.should_receive(:rotate)
-        Zenflow::Shell.should_receive(:run).with("git add CHANGELOG.md && git commit -a -m 'Adding line to CHANGELOG: changed the world'")
+        Zenflow::Shell.should_receive(:run).with("git add CHANGELOG.md && git commit -m 'Adding line to CHANGELOG: changed the world'")
         Zenflow::Changelog.prepend_change_to_changelog('changed the world', :rotate => true)
       end
     end
@@ -121,7 +121,7 @@ describe Zenflow::Changelog do
           file_handler = double()
           file_handler.should_receive(:write).with('amazing new changelog')
           File.should_receive(:open).with("CHANGELOG.md", "w").and_yield(file_handler)
-          Zenflow::Shell.should_receive(:run).with("git add CHANGELOG.md && git commit -a -m 'Rotating CHANGELOG.'")
+          Zenflow::Shell.should_receive(:run).with("git add CHANGELOG.md && git commit -m 'Rotating CHANGELOG.'")
           Zenflow::Changelog.rotate(:commit => true)
         end
       end


### PR DESCRIPTION
Removing the "-a" flag from `git commit` to avoid accidentally commiting unstaged files when updating the CHANGELOG.md or VERSION.yml files.