### PR TITLE
upd(Doc): .git/config instead of ~/.github

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,13 +40,15 @@ Zenflow will perform some actions with GitHub (opening pull requests, for exampl
 
 Visit https://github.com/settings/tokens to create a token for Zenflow (for this purpose, "no expiration" is appropriate).
 
-Once you have your token, you can add it to your `~/.github`, e.g.:
+Once you have your token, you can add it to the `.git/config`, e.g.:
 
 ```
 [zenflow]
 	user = yourgithandle
 	token = <snip>
 ```
+
+If this configuration is not set, you'll get a "weird" error when you use `zenflow feature review`
 
 ### <a name="usage"></a> Usage
 


### PR DESCRIPTION
Updating README to have the `zenflow <whatever> review` working with github